### PR TITLE
docs(docs): add search console verification token

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,11 @@
       name="description"
       content="Firebase Tools CLI - Command-line interface for managing Firebase services"
     />
+    <!-- Replace with your Google Search Console verification token -->
+    <meta
+      name="google-site-verification"
+      content="04mz6pSn54ObjKrF-JxrcA-hvwFgRNBZhyFiAVZdlOo"
+    />
     <title>Firebase Tools CLI</title>
     <style>
       * {


### PR DESCRIPTION
## Summary
Add the Google Search Console verification meta tag token to the docs homepage so site ownership can be verified for OAuth app verification.

## Related
- Related to OAuth verification follow-up

## PR Checklist
- [x] PR title is non-empty (conventional format recommended but not required)
- [x] All commit messages follow Conventional Commits format
- [ ] npm ci passes without errors
- [ ] npx tsc --noEmit passes
- [ ] npx prettier --check "src/**/*.{ts,js,json}" passes
- [ ] npm run build produces a working dist/
- [ ] npm pack && npm install -g firebase-tools-cli-*.tgz && firebase-tools-cli --help succeeds
- [x] No dist/ files are committed
- [ ] Documentation updated if user-facing functionality changed
- [ ] Relevant issue linked (non-issue PRs are not merged)
